### PR TITLE
Add Fedora badge for simframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![GitHub](https://img.shields.io/github/license/stammler/simframe) 
 [![status](https://joss.theoj.org/papers/0ef61e034c57445e846b2ec383c920a6/status.svg)](https://joss.theoj.org/papers/0ef61e034c57445e846b2ec383c920a6) 
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/simframe?label=PyPI%20downloads)
+[![Fedora package](https://img.shields.io/fedora/v/python3-simframe?color=blue&label=Fedora%20Linux&logo=fedora)](https://src.fedoraproject.org/rpms/python-simframe)
 
 ### Framework for scientific simulations
 


### PR DESCRIPTION
Package **simframe** is now also available as rpm package for **Fedora linux**. It can be installed using the following command: **dnf install python3-simframe**

Thus, I suggest to add this badge which shows the recent version of **simframe** in **Fedora package repository.**