### PR TITLE
Install as pure-Python

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('simframe', 'c')
 
 py_mod = import('python')
-py3 = py_mod.find_installation(pure: false)
+py3 = py_mod.find_installation(pure: true)
 py_dep = py3.dependency()
 
 subdir('simframe')


### PR DESCRIPTION
# Pull Requests

Please have a look the [contribution guidelines](https://github.com/stammler/simframe/blob/master/.github/CONTRIBUTING.md).

## Reference issue

N/A

## Describe the changes

Set `pure : true` when calling `py_mod.find_installation()`.

## Additional information

Since the project currently contains only pure-Python sources, it does not need to be arch-specific.

In a system-wide installation such as Fedora’s [`python-simframe` package](https://src.fedoraproject.org/rpms/python-simframe), this means the module would be installed in e.g. `/usr/lib/python3.13/site-packages/simframe/` rather than `/usr/lib64/python3.13/site-packages/simframe/`.

This can and should be reverted if any actual C sources or other compiled extension modules are ever added.